### PR TITLE
feat(test): increase timeout and add animation/loader waiters

### DIFF
--- a/IMPROVEMENTS.md
+++ b/IMPROVEMENTS.md
@@ -90,3 +90,47 @@ Consider implementing these additional improvements:
 3. **Performance Optimization**: Make Tesseract.js OCR optional for better performance
 4. **Reporting**: Enhance reporting with more detailed statistics
 5. **CI/CD Integration**: Improve CI/CD workflows with parallel execution
+
+---
+
+Using this custom `waitForPageReady` function solves the **three biggest causes of flaky tests** in modern web automation.
+
+Here is a detailed breakdown of why this approach is superior to standard Playwright waits (`networkidle`, `waitForTimeout`, or simple element assertions).
+
+### 1. It Solves the "Rendering Gap"
+**The Problem:** Standard waits like `networkidle` only check the *Network*. They return `true` the millisecond the JSON data arrives from the server.
+* **Real World Failure:** Modern frameworks (React, Vue, Angular) take 100-500ms *after* the data arrives to process it and paint the HTML.
+* **Result:** Your test clicks a button that doesn't exist yet, or takes a screenshot of a blank skeleton screen.
+
+**Your Solution:** The `waitForDOMStability` component explicitly waits for the HTML to **stop moving**. It ensures the browser has finished painting the UI updates triggered by that network call.
+
+### 2. It Detects "Fake" Loading States
+**The Problem:** Many sites use client-side delays (like `setTimeout`) or CSS animations that don't trigger network activity.
+* **Real World Failure:** On the "The Internet" example you shared, `networkidle` returns immediately because no API is called. The page is just running a 5-second timer.
+* **Result:** Playwright thinks the page is ready, clicks a button, and fails because a "Loading..." overlay is actually blocking it.
+
+**Your Solution:** The `waitForCommonLoaders` and `waitForAnimations` functions act like a human eye. They scan for visible spinners, progress bars, or moving pixels (`aria-busy`, `.loader`, CSS transitions) and force the test to pause until they vanish.
+
+### 3. It Eliminates Hardcoded Sleeps (`waitForTimeout`)
+**The Problem:** When tests are flaky, developers often add `await page.waitForTimeout(5000)`.
+* **Real World Failure:**
+    * **On Fast Days:** You waste 4 seconds waiting for nothing. Over 100 tests, this adds minutes to your build time.
+    * **On Slow Days:** The 5-second wait isn't enough, and the test crashes anyway.
+
+**Your Solution:** This function is **adaptive**.
+* If the API takes 200ms, it waits ~250ms.
+* If the API takes 10 seconds, it waits 10.5 seconds.
+* It is always fast enough, but never too fast.
+
+### Comparison: Standard vs. Your Custom Function
+
+| Feature | `networkidle` | `waitForTimeout(5000)` | **Your `waitForPageReady`** |
+| :--- | :--- | :--- | :--- |
+| **Waits for API Data?** | ✅ Yes | ⚠️ Maybe (if < 5s) | ✅ **Yes (Strict)** |
+| **Waits for UI Painting?** | ❌ No | ⚠️ Maybe | ✅ **Yes (DOM Stability)** |
+| **Waits for CSS Spinners?** | ❌ No | ⚠️ Maybe | ✅ **Yes (Animation Check)** |
+| **Speed** | ⚡️ Fast | 🐌 Slow (Always 5s) | ⚡️ **Optimized** |
+| **Flakiness** | High (on SPAs) | Low (but slow) | **Zero** |
+
+### Summary for your Team
+> "We use `waitForPageReady` because modern web apps are asynchronous. Standard waits only tell us when the *server* is done, but this function tells us when the *user* can actually interact with the page. It intelligently watches the Network, the DOM, and Visual Animations simultaneously to ensure stability without hardcoded delays."

--- a/globalSetup.js
+++ b/globalSetup.js
@@ -1,0 +1,31 @@
+import {
+  initDatabaseConnection,
+  initDatabaseSchema,
+} from "./utils/db-service.js";
+
+/**
+ * Global setup function for initializing the database schema.
+ * Determines the runtime environment (CI or Local) and logs appropriate messages.
+ * 
+ * @async
+ * @function globalSetup
+ * @throws {Error} Throws an error if database initialization fails.
+ * @returns {Promise<void>} Resolves when the database schema is successfully initialized.
+ */
+async function globalSetup() {
+  const environment = process.env.CI ? "CI" : "Local";
+  console.log(`🚀 Global Setup [${environment}]: Initializing database schema...`);
+
+  try {
+    const db = initDatabaseConnection();
+    initDatabaseSchema(db);
+    db.close();
+    
+    console.log(`✅ Global Setup [${environment}]: Database schema created successfully`);
+  } catch (error) {
+    console.error(`❌ Global Setup [${environment}]: Database initialization failed:`, error);
+    throw error;
+  }
+}
+
+export default globalSetup;

--- a/globalTeardown.js
+++ b/globalTeardown.js
@@ -1,0 +1,23 @@
+import { DatabaseManager } from "./utils/db-service.js";
+
+/**
+ * Global teardown function that performs cleanup tasks after tests finish running.
+ * Closes the database connection and logs the teardown status.
+ * 
+ * @async
+ * @function globalTeardown
+ * @returns {Promise<void>} A promise that resolves when teardown is complete.
+ */
+async function globalTeardown() {
+  console.log("🧹 Global Teardown: Cleaning up...");
+  
+  try {
+    const dbManager = DatabaseManager.getInstance();
+    dbManager.closeConnection();
+    console.log("✅ Global Teardown: Complete");
+  } catch (error) {
+    console.warn("⚠️ Global Teardown: Error during cleanup:", error.message);
+  }
+}
+
+export default globalTeardown;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "ISC",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.71.2",
-        "@arghajit/playwright-pulse-report": "^0.2.9",
         "@google/genai": "^1.31.0",
         "@supabase/supabase-js": "^2.49.1",
         "better-sqlite3": "^12.4.6",
@@ -24,7 +23,7 @@
         "tesseract.js": "^5.1.1"
       },
       "devDependencies": {
-        "@arghajit/playwright-pulse-report": "^0.2.9",
+        "@arghajit/playwright-pulse-report": "^0.2.10",
         "@playwright/test": "^1.49.1",
         "@types/node": "^22.10.2",
         "allure-commandline": "^2.32.0",
@@ -52,9 +51,10 @@
       }
     },
     "node_modules/@arghajit/playwright-pulse-report": {
-      "version": "0.2.9",
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@arghajit/playwright-pulse-report/-/playwright-pulse-report-0.2.10.tgz",
+      "integrity": "sha512-m/9f2bgz2slc7IHbuxBV4427PBkaFwulZuT8704d+z+9mdvB5mBS1rkgpMaXme16Vk3jqqRAHFGgrmHuffO+Tg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "archiver": "^7.0.1",
         "class-variance-authority": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@arghajit/playwright-pulse-report": "^0.2.9",
+    "@arghajit/playwright-pulse-report": "^0.2.10",
     "@playwright/test": "^1.49.1",
     "@types/node": "^22.10.2",
     "allure-commandline": "^2.32.0",
@@ -30,8 +30,7 @@
     "netlify-cli": "^23.11.1",
     "node-forge": "^1.3.2",
     "playwright": "^1.49.1",
-    "tesseract.js": "^5.1.1",
-    "@arghajit/playwright-pulse-report": "^0.2.9"
+    "tesseract.js": "^5.1.1"
   },
   "overrides": {
     "glob": "^13.0.0",

--- a/playwright-report.json
+++ b/playwright-report.json
@@ -1,0 +1,535 @@
+{
+  "config": {
+    "configFile": "/Users/arghajitsingha/Playwright-Visual-Testing/playwright.config.js",
+    "rootDir": "/Users/arghajitsingha/Playwright-Visual-Testing",
+    "forbidOnly": false,
+    "fullyParallel": false,
+    "globalSetup": "/Users/arghajitsingha/Playwright-Visual-Testing/globalSetup.js",
+    "globalTeardown": "/Users/arghajitsingha/Playwright-Visual-Testing/globalTeardown.js",
+    "globalTimeout": 0,
+    "grep": {},
+    "grepInvert": null,
+    "maxFailures": 0,
+    "metadata": {
+      "actualWorkers": 4
+    },
+    "preserveOutput": "always",
+    "reporter": [
+      [
+        "html",
+        {
+          "open": "never"
+        }
+      ],
+      [
+        "json",
+        {
+          "outputFile": "playwright-report.json"
+        }
+      ],
+      [
+        "/Users/arghajitsingha/Playwright-Visual-Testing/node_modules/allure-playwright/dist/cjs/index.js",
+        {
+          "open": "never"
+        }
+      ],
+      [
+        "/Users/arghajitsingha/Playwright-Visual-Testing/node_modules/@arghajit/playwright-pulse-report/dist/reporter/index.js",
+        {
+          "outputDir": "/Users/arghajitsingha/Playwright-Visual-Testing/pulse-report"
+        }
+      ]
+    ],
+    "reportSlowTests": {
+      "max": 5,
+      "threshold": 300000
+    },
+    "quiet": false,
+    "projects": [
+      {
+        "outputDir": "/Users/arghajitsingha/Playwright-Visual-Testing/test-results",
+        "repeatEach": 1,
+        "retries": 0,
+        "metadata": {
+          "actualWorkers": 4
+        },
+        "id": "Visual-Desktop-Test",
+        "name": "Visual-Desktop-Test",
+        "testDir": "/Users/arghajitsingha/Playwright-Visual-Testing/tests/DesktopView",
+        "testIgnore": [],
+        "testMatch": [
+          "**/*.@(spec|test).?(c|m)[jt]s?(x)"
+        ],
+        "timeout": 150000
+      },
+      {
+        "outputDir": "/Users/arghajitsingha/Playwright-Visual-Testing/test-results",
+        "repeatEach": 1,
+        "retries": 0,
+        "metadata": {
+          "actualWorkers": 4
+        },
+        "id": "Visual-Mobile-Test",
+        "name": "Visual-Mobile-Test",
+        "testDir": "/Users/arghajitsingha/Playwright-Visual-Testing/tests/MobileView",
+        "testIgnore": [],
+        "testMatch": [
+          "**/*.@(spec|test).?(c|m)[jt]s?(x)"
+        ],
+        "timeout": 150000
+      }
+    ],
+    "shard": null,
+    "updateSnapshots": "missing",
+    "updateSourceMethod": "patch",
+    "version": "1.56.1",
+    "workers": 4,
+    "webServer": null
+  },
+  "suites": [
+    {
+      "title": "tests/MobileView/visual-computers-element-page.spec.js",
+      "file": "tests/MobileView/visual-computers-element-page.spec.js",
+      "column": 0,
+      "line": 0,
+      "specs": [],
+      "suites": [
+        {
+          "title": "Take screenshots for Visual Regression Testing - Computers page",
+          "file": "tests/MobileView/visual-computers-element-page.spec.js",
+          "line": 32,
+          "column": 6,
+          "specs": [
+            {
+              "title": "Computers page Upper Header - Mobile - Validate Mismatch",
+              "ok": true,
+              "tags": [
+                "validation"
+              ],
+              "tests": [
+                {
+                  "timeout": 150000,
+                  "annotations": [],
+                  "expectedStatus": "passed",
+                  "projectId": "Visual-Mobile-Test",
+                  "projectName": "Visual-Mobile-Test",
+                  "results": [
+                    {
+                      "workerIndex": 0,
+                      "parallelIndex": 0,
+                      "status": "passed",
+                      "duration": 10889,
+                      "errors": [],
+                      "stdout": [
+                        {
+                          "text": "No text differences found.\n"
+                        },
+                        {
+                          "text": "✅ Test passed: Mismatch 0% is below tolerance 1%\n"
+                        },
+                        {
+                          "text": "✅ Connected to database: visual.db\n"
+                        },
+                        {
+                          "text": "PRAGMA journal_mode = WAL\n"
+                        },
+                        {
+                          "text": "PRAGMA synchronous = NORMAL\n"
+                        },
+                        {
+                          "text": "CREATE TABLE IF NOT EXISTS visual_matrix (\n        id INTEGER PRIMARY KEY AUTOINCREMENT,\n        name TEXT NOT NULL,\n        device TEXT NOT NULL,\n        status TEXT NOT NULL,\n        imageUrl TEXT NOT NULL,\n        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP\n      );\n"
+                        },
+                        {
+                          "text": "CREATE TABLE IF NOT EXISTS baseline (\n        id INTEGER PRIMARY KEY AUTOINCREMENT,\n        name TEXT NOT NULL,\n        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP\n      );\n"
+                        },
+                        {
+                          "text": "✅ Database schema initialized\n"
+                        },
+                        {
+                          "text": "\n      INSERT INTO visual_matrix (\n        name, \n        device, \n        status, \n        imageUrl\n      ) VALUES (\n        'Computers page Upper Header - Mo'/*+24 bytes*/, \n        'Mobile', \n        'passed', \n        ''\n      )\n    \n"
+                        },
+                        {
+                          "text": "✅ Record inserted with ID: 127\n"
+                        }
+                      ],
+                      "stderr": [
+                        {
+                          "text": "looksSame returned undefined pixel values for both differentPixels and totalPixels, treating as no differences\n"
+                        }
+                      ],
+                      "retry": 0,
+                      "startTime": "2025-12-14T17:58:22.930Z",
+                      "annotations": [],
+                      "attachments": [
+                        {
+                          "name": "Allure Metadata (metadata)",
+                          "contentType": "application/vnd.allure.message+json",
+                          "body": "eyJ0eXBlIjoibWV0YWRhdGEiLCJkYXRhIjp7ImxhYmVscyI6W3sibmFtZSI6InNldmVyaXR5IiwidmFsdWUiOiJtaW5vciJ9XX19"
+                        }
+                      ]
+                    }
+                  ],
+                  "status": "expected"
+                }
+              ],
+              "id": "dc63e34a6327da4d871b-0b36d6dd67fcc325ba0c",
+              "file": "tests/MobileView/visual-computers-element-page.spec.js",
+              "line": 107,
+              "column": 3
+            },
+            {
+              "title": "Computers page Lower Header - Mobile - Validate Mismatch",
+              "ok": true,
+              "tags": [
+                "validation"
+              ],
+              "tests": [
+                {
+                  "timeout": 150000,
+                  "annotations": [],
+                  "expectedStatus": "passed",
+                  "projectId": "Visual-Mobile-Test",
+                  "projectName": "Visual-Mobile-Test",
+                  "results": [
+                    {
+                      "workerIndex": 0,
+                      "parallelIndex": 0,
+                      "status": "passed",
+                      "duration": 5485,
+                      "errors": [],
+                      "stdout": [
+                        {
+                          "text": "No text differences found.\n"
+                        },
+                        {
+                          "text": "✅ Test passed: Mismatch 0% is below tolerance 1%\n"
+                        },
+                        {
+                          "text": "\n      INSERT INTO visual_matrix (\n        name, \n        device, \n        status, \n        imageUrl\n      ) VALUES (\n        'Computers page Lower Header - Mo'/*+24 bytes*/, \n        'Mobile', \n        'passed', \n        ''\n      )\n    \n"
+                        },
+                        {
+                          "text": "✅ Record inserted with ID: 129\n"
+                        }
+                      ],
+                      "stderr": [
+                        {
+                          "text": "looksSame returned undefined pixel values for both differentPixels and totalPixels, treating as no differences\n"
+                        }
+                      ],
+                      "retry": 0,
+                      "startTime": "2025-12-14T17:58:34.851Z",
+                      "annotations": [],
+                      "attachments": [
+                        {
+                          "name": "Allure Metadata (metadata)",
+                          "contentType": "application/vnd.allure.message+json",
+                          "body": "eyJ0eXBlIjoibWV0YWRhdGEiLCJkYXRhIjp7ImxhYmVscyI6W3sibmFtZSI6InNldmVyaXR5IiwidmFsdWUiOiJtaW5vciJ9XX19"
+                        }
+                      ]
+                    }
+                  ],
+                  "status": "expected"
+                }
+              ],
+              "id": "dc63e34a6327da4d871b-ab0164cb6162a4605a0b",
+              "file": "tests/MobileView/visual-computers-element-page.spec.js",
+              "line": 144,
+              "column": 3
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "tests/MobileView/visual-computers-page.spec.js",
+      "file": "tests/MobileView/visual-computers-page.spec.js",
+      "column": 0,
+      "line": 0,
+      "specs": [],
+      "suites": [
+        {
+          "title": "Take screenshots for Visual Regression Testing - Computers page",
+          "file": "tests/MobileView/visual-computers-page.spec.js",
+          "line": 26,
+          "column": 6,
+          "specs": [
+            {
+              "title": "Computers page - Mobile - Validate Mismatch",
+              "ok": true,
+              "tags": [
+                "validation"
+              ],
+              "tests": [
+                {
+                  "timeout": 150000,
+                  "annotations": [],
+                  "expectedStatus": "passed",
+                  "projectId": "Visual-Mobile-Test",
+                  "projectName": "Visual-Mobile-Test",
+                  "results": [
+                    {
+                      "workerIndex": 1,
+                      "parallelIndex": 1,
+                      "status": "passed",
+                      "duration": 17863,
+                      "errors": [],
+                      "stdout": [
+                        {
+                          "text": "No text differences found.\n"
+                        },
+                        {
+                          "text": "✅ Test passed: Mismatch 0% is below tolerance 1%\n"
+                        },
+                        {
+                          "text": "✅ Connected to database: visual.db\n"
+                        },
+                        {
+                          "text": "PRAGMA journal_mode = WAL\n"
+                        },
+                        {
+                          "text": "PRAGMA synchronous = NORMAL\n"
+                        },
+                        {
+                          "text": "CREATE TABLE IF NOT EXISTS visual_matrix (\n        id INTEGER PRIMARY KEY AUTOINCREMENT,\n        name TEXT NOT NULL,\n        device TEXT NOT NULL,\n        status TEXT NOT NULL,\n        imageUrl TEXT NOT NULL,\n        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP\n      );\n"
+                        },
+                        {
+                          "text": "CREATE TABLE IF NOT EXISTS baseline (\n        id INTEGER PRIMARY KEY AUTOINCREMENT,\n        name TEXT NOT NULL,\n        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP\n      );\n"
+                        },
+                        {
+                          "text": "✅ Database schema initialized\n"
+                        },
+                        {
+                          "text": "\n      INSERT INTO visual_matrix (\n        name, \n        device, \n        status, \n        imageUrl\n      ) VALUES (\n        'Computers page - Mobile - Valida'/*+11 bytes*/, \n        'Mobile', \n        'passed', \n        ''\n      )\n    \n"
+                        },
+                        {
+                          "text": "✅ Record inserted with ID: 130\n"
+                        }
+                      ],
+                      "stderr": [
+                        {
+                          "text": "looksSame returned undefined pixel values for both differentPixels and totalPixels, treating as no differences\n"
+                        }
+                      ],
+                      "retry": 0,
+                      "startTime": "2025-12-14T17:58:22.966Z",
+                      "annotations": [],
+                      "attachments": [
+                        {
+                          "name": "Allure Metadata (metadata)",
+                          "contentType": "application/vnd.allure.message+json",
+                          "body": "eyJ0eXBlIjoibWV0YWRhdGEiLCJkYXRhIjp7ImxhYmVscyI6W3sibmFtZSI6InNldmVyaXR5IiwidmFsdWUiOiJtaW5vciJ9XX19"
+                        }
+                      ]
+                    }
+                  ],
+                  "status": "expected"
+                }
+              ],
+              "id": "0f87a28e5fd72d10e534-05f4cacb35aee703e72c",
+              "file": "tests/MobileView/visual-computers-page.spec.js",
+              "line": 73,
+              "column": 3
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "tests/MobileView/visual-nopcommerce-home-page.spec.js",
+      "file": "tests/MobileView/visual-nopcommerce-home-page.spec.js",
+      "column": 0,
+      "line": 0,
+      "specs": [],
+      "suites": [
+        {
+          "title": "Take screenshots for Visual Regression Testing - Nopcommerce home page",
+          "file": "tests/MobileView/visual-nopcommerce-home-page.spec.js",
+          "line": 26,
+          "column": 6,
+          "specs": [
+            {
+              "title": "Nopcommerce home page - Mobile - Validate Mismatch",
+              "ok": true,
+              "tags": [
+                "validation"
+              ],
+              "tests": [
+                {
+                  "timeout": 150000,
+                  "annotations": [],
+                  "expectedStatus": "passed",
+                  "projectId": "Visual-Mobile-Test",
+                  "projectName": "Visual-Mobile-Test",
+                  "results": [
+                    {
+                      "workerIndex": 2,
+                      "parallelIndex": 2,
+                      "status": "passed",
+                      "duration": 29186,
+                      "errors": [],
+                      "stdout": [
+                        {
+                          "text": "No text differences found.\n"
+                        },
+                        {
+                          "text": "✅ Test passed: Mismatch 0% is below tolerance 1%\n"
+                        },
+                        {
+                          "text": "✅ Connected to database: visual.db\n"
+                        },
+                        {
+                          "text": "PRAGMA journal_mode = WAL\n"
+                        },
+                        {
+                          "text": "PRAGMA synchronous = NORMAL\n"
+                        },
+                        {
+                          "text": "CREATE TABLE IF NOT EXISTS visual_matrix (\n        id INTEGER PRIMARY KEY AUTOINCREMENT,\n        name TEXT NOT NULL,\n        device TEXT NOT NULL,\n        status TEXT NOT NULL,\n        imageUrl TEXT NOT NULL,\n        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP\n      );\n"
+                        },
+                        {
+                          "text": "CREATE TABLE IF NOT EXISTS baseline (\n        id INTEGER PRIMARY KEY AUTOINCREMENT,\n        name TEXT NOT NULL,\n        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP\n      );\n"
+                        },
+                        {
+                          "text": "✅ Database schema initialized\n"
+                        },
+                        {
+                          "text": "\n      INSERT INTO visual_matrix (\n        name, \n        device, \n        status, \n        imageUrl\n      ) VALUES (\n        'Nopcommerce home page - Mobile -'/*+18 bytes*/, \n        'Mobile', \n        'passed', \n        ''\n      )\n    \n"
+                        },
+                        {
+                          "text": "✅ Record inserted with ID: 131\n"
+                        }
+                      ],
+                      "stderr": [
+                        {
+                          "text": "looksSame returned undefined pixel values for both differentPixels and totalPixels, treating as no differences\n"
+                        }
+                      ],
+                      "retry": 0,
+                      "startTime": "2025-12-14T17:58:22.927Z",
+                      "annotations": [],
+                      "attachments": [
+                        {
+                          "name": "Allure Metadata (metadata)",
+                          "contentType": "application/vnd.allure.message+json",
+                          "body": "eyJ0eXBlIjoibWV0YWRhdGEiLCJkYXRhIjp7ImxhYmVscyI6W3sibmFtZSI6InNldmVyaXR5IiwidmFsdWUiOiJtaW5vciJ9XX19"
+                        }
+                      ]
+                    }
+                  ],
+                  "status": "expected"
+                }
+              ],
+              "id": "8aa0cda2f98b5b703202-c2bd98d58a25d7aed3fb",
+              "file": "tests/MobileView/visual-nopcommerce-home-page.spec.js",
+              "line": 72,
+              "column": 3
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "title": "tests/MobileView/visual-the-internet-page.spec.js",
+      "file": "tests/MobileView/visual-the-internet-page.spec.js",
+      "column": 0,
+      "line": 0,
+      "specs": [],
+      "suites": [
+        {
+          "title": "Take screenshots for Visual Regression Testing - The Internat webpage",
+          "file": "tests/MobileView/visual-the-internet-page.spec.js",
+          "line": 30,
+          "column": 6,
+          "specs": [
+            {
+              "title": "The Internet webpage - Mobile - Validate Mismatch",
+              "ok": true,
+              "tags": [
+                "validation"
+              ],
+              "tests": [
+                {
+                  "timeout": 150000,
+                  "annotations": [],
+                  "expectedStatus": "passed",
+                  "projectId": "Visual-Mobile-Test",
+                  "projectName": "Visual-Mobile-Test",
+                  "results": [
+                    {
+                      "workerIndex": 3,
+                      "parallelIndex": 3,
+                      "status": "passed",
+                      "duration": 14951,
+                      "errors": [],
+                      "stdout": [
+                        {
+                          "text": "No text differences found.\n"
+                        },
+                        {
+                          "text": "✅ Test passed: Mismatch 0% is below tolerance 1%\n"
+                        },
+                        {
+                          "text": "✅ Connected to database: visual.db\n"
+                        },
+                        {
+                          "text": "PRAGMA journal_mode = WAL\n"
+                        },
+                        {
+                          "text": "PRAGMA synchronous = NORMAL\n"
+                        },
+                        {
+                          "text": "CREATE TABLE IF NOT EXISTS visual_matrix (\n        id INTEGER PRIMARY KEY AUTOINCREMENT,\n        name TEXT NOT NULL,\n        device TEXT NOT NULL,\n        status TEXT NOT NULL,\n        imageUrl TEXT NOT NULL,\n        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP\n      );\n"
+                        },
+                        {
+                          "text": "CREATE TABLE IF NOT EXISTS baseline (\n        id INTEGER PRIMARY KEY AUTOINCREMENT,\n        name TEXT NOT NULL,\n        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP\n      );\n"
+                        },
+                        {
+                          "text": "✅ Database schema initialized\n"
+                        },
+                        {
+                          "text": "\n      INSERT INTO visual_matrix (\n        name, \n        device, \n        status, \n        imageUrl\n      ) VALUES (\n        'The Internet webpage - Mobile - '/*+17 bytes*/, \n        'Mobile', \n        'passed', \n        ''\n      )\n    \n"
+                        },
+                        {
+                          "text": "✅ Record inserted with ID: 128\n"
+                        }
+                      ],
+                      "stderr": [
+                        {
+                          "text": "looksSame returned undefined pixel values for both differentPixels and totalPixels, treating as no differences\n"
+                        }
+                      ],
+                      "retry": 0,
+                      "startTime": "2025-12-14T17:58:22.971Z",
+                      "annotations": [],
+                      "attachments": [
+                        {
+                          "name": "Allure Metadata (metadata)",
+                          "contentType": "application/vnd.allure.message+json",
+                          "body": "eyJ0eXBlIjoibWV0YWRhdGEiLCJkYXRhIjp7ImxhYmVscyI6W3sibmFtZSI6InNldmVyaXR5IiwidmFsdWUiOiJtaW5vciJ9XX19"
+                        }
+                      ]
+                    }
+                  ],
+                  "status": "expected"
+                }
+              ],
+              "id": "8e4be46a8717a117becc-f1d0c55cb506552a4662",
+              "file": "tests/MobileView/visual-the-internet-page.spec.js",
+              "line": 78,
+              "column": 3
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "errors": [],
+  "stats": {
+    "startTime": "2025-12-14T17:58:20.867Z",
+    "duration": 32444.724000000002,
+    "expected": 5,
+    "skipped": 0,
+    "unexpected": 0,
+    "flaky": 0
+  }
+}

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -17,7 +17,7 @@ const PULSE_REPORT_DIR = path.resolve(__dirname, "pulse-report"); // Example: a 
 module.exports = defineConfig({
   // This sets the maximum time (in ms) each test can run.
   // Equivalent to calling test.setTimeout(12222) in every file.
-  timeout: 120000,
+  timeout: 150000,
   /* Run tests in files in parallel */
   fullyParallel: false,
   /* Fail the build on CI if you accidentally left test.only in the source code. */

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -15,6 +15,8 @@ const PULSE_REPORT_DIR = path.resolve(__dirname, "pulse-report"); // Example: a 
  * @see https://playwright.dev/docs/test-configuration
  */
 module.exports = defineConfig({
+  globalSetup: require.resolve('./globalSetup.js'),
+  globalTeardown: require.resolve('./globalTeardown.js'),
   // This sets the maximum time (in ms) each test can run.
   // Equivalent to calling test.setTimeout(12222) in every file.
   timeout: 150000,

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -47,6 +47,7 @@ module.exports = defineConfig({
       ]
     : [
         ["html", { open: "never" }],
+        ["json", { outputFile: "playwright-report.json" }],
         ["allure-playwright", { open: "never" }],
         [
           "@arghajit/playwright-pulse-report",

--- a/tests/MobileView/visual-the-internet-page.spec.js
+++ b/tests/MobileView/visual-the-internet-page.spec.js
@@ -16,8 +16,8 @@ const {
 const {
   BASELINE_DIR,
   DIFF_DIR,
-  BASELINE_DESKTOP_DIR,
   CURRENT_DIR,
+  BASELINE_MOBILE_DIR,
   currentMobileScreenshot,
   baselineMobileScreenshot,
   diffMobileScreenshot,
@@ -61,7 +61,7 @@ test.describe("Take screenshots for Visual Regression Testing - The Internat web
         baselineMobileScreenshot(test.info().title)
       );
       await uploadImage(
-        `${BASELINE_DESKTOP_DIR}/${generateScreenshotName(
+        `${BASELINE_MOBILE_DIR}/${generateScreenshotName(
           test.info().title
         )}-baseline.png`,
         baselineMobileScreenshot(test.info().title)


### PR DESCRIPTION
- Increase global test timeout from 120s to 150s
- Add new waitForAnimations utility to handle CSS animations
- Add new waitForCommonLoaders utility to detect loading indicators
- Update mobile test paths to use BASELINE_MOBILE_DIR