### PR TITLE
feat(gen-ai): add image compression for AI payload optimization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "netlify-cli": "^23.11.1",
         "node-forge": "^1.3.2",
         "playwright": "^1.49.1",
+        "sharp": "^0.34.5",
         "tesseract.js": "^5.1.1"
       },
       "devDependencies": {
@@ -15581,8 +15582,9 @@
     },
     "node_modules/sharp": {
       "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
       "hasInstallScript": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "@img/colour": "^1.0.0",
         "detect-libc": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "netlify-cli": "^23.11.1",
     "node-forge": "^1.3.2",
     "playwright": "^1.49.1",
+    "sharp": "^0.34.5",
     "tesseract.js": "^5.1.1"
   },
   "overrides": {


### PR DESCRIPTION
Add sharp dependency and implement image compression logic for both Gemini and Claude AI integrations. The compression is triggered when image payloads exceed 5MB, resizing images to 1920px and progressively reducing JPEG quality to meet size constraints. This prevents API failures due to payload size limits while maintaining acceptable image quality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced image handling with automatic compression for large payloads exceeding 5 MB
  * Implemented dynamic image format optimization to improve processing efficiency
  * Strengthened robustness for AI-powered image analysis across multiple vision platforms
  * Added comprehensive payload size monitoring and reporting

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->